### PR TITLE
[bugfix] TypeError: 'AccessMaskFlags' object is not iterable

### DIFF
--- a/DescribeNTSecurityDescriptor.py
+++ b/DescribeNTSecurityDescriptor.py
@@ -2491,7 +2491,7 @@ class HumanDescriber(object):
             "GENERIC_READ": "Generic Read"
         }
         rights = []
-        access_flags = list(AccessMaskFlags(ace.mask.AccessMask))
+        access_flags = [flag for flag in AccessMaskFlags if flag & ace.mask.AccessMask.value]
         for flag in access_flags:
             rights.append(mapping[flag.name])
         


### PR DESCRIPTION
While using the `--describe` mode, the following error happens:

```
  File "/home/user/pyDescribeNTSecurityDescriptor/DescribeNTSecurityDescriptor.py", line 2664, in <module>
    HumanDescriber(ntsd=ntsd).summary()
  File "/home/user/pyDescribeNTSecurityDescriptor/DescribeNTSecurityDescriptor.py", line 2426, in summary
    self.explain_ace(ace=ace, entry_id=entry_id)
  File "/home/user/pyDescribeNTSecurityDescriptor/DescribeNTSecurityDescriptor.py", line 2442, in explain_ace
    str_rights = self.explain_access_mask(ace=ace)
  File "/home/user/pyDescribeNTSecurityDescriptor/DescribeNTSecurityDescriptor.py", line 2494, in explain_access_mask
    access_flags = list(AccessMaskFlags(ace.mask.AccessMask))
TypeError: 'AccessMaskFlags' object is not iterable
```

This is due the attempt to convert a combined flag object to a list, which is not iterable. The fix  iterates over all enum members and uses bitwise checks to extract the active flags correctly.