### PR TITLE
Bump up sectools version

### DIFF
--- a/DescribeNTSecurityDescriptor.py
+++ b/DescribeNTSecurityDescriptor.py
@@ -10,7 +10,7 @@ from enum import Enum, IntFlag
 import io
 import ldap3
 from ldap3.protocol.formatters.formatters import format_sid
-from sectools.windows.ldap import raw_ldap_query, init_ldap_session
+from sectools.windows.ldap.ldap import raw_ldap_query, init_ldap_session
 from sectools.windows.crypto import nt_hash, parse_lm_nt_hashes
 import os
 import random

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 ldap3
-sectools>=1.4.3
+sectools>=1.5.1
 pycryptodome


### PR DESCRIPTION
identical to https://github.com/p0dalirius/GhostSPN/issues/2

pip installs most recent sectools version by default, which uses sectools.windows.ldap.ldap instead of sectools.windows.ldap